### PR TITLE
fix: redis template 빈이 생성되지 않는 문제 해결 

### DIFF
--- a/src/main/java/org/pokeherb/hubservice/infrastructure/config/RedisConfig.java
+++ b/src/main/java/org/pokeherb/hubservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package org.pokeherb.hubservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}


### PR DESCRIPTION
- 제목 : feat(#15): redis template 빈 미등록 문제 해결

## 🔘Part

- infrastructure.config

## 🔎 작업 내용

- RedisTemplate<String, String>은 자동적으로 빈으로 등록되지만, 그 외에는 직접 등록해야함
- RedisTemplate<String, Object>를 사용하지만 빈으로 등록하지 않아 문제 발생
- RedisTemplate<String, String>을 직접 빈으로 등록하여 해결


## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#15](https://github.com/PokeHerb/hub-service/issues/15)